### PR TITLE
Fix upload release manifest ci job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,9 @@ jobs:
     needs: [docker-build]
     if: github.event_name == 'release'
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Download manifest artifact
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Error: 
`failed to run git: fatal: not a git repository (or any of the parent directories): .git`