### PR TITLE
Do not track last active when scale to zero is disabled

### DIFF
--- a/internal/sidecar/scale_to_zero_test.go
+++ b/internal/sidecar/scale_to_zero_test.go
@@ -318,6 +318,48 @@ func TestScaleToZero_isClusterActive(t *testing.T) {
 		wantErr        error
 	}{
 		{
+			name:   "last active is zero, cluster is not active",
+			client: &mockClusterClient{},
+			querier: &mockQuerier{
+				queryFunc: func(ctx context.Context, query string, args ...any) (postgres.Row, error) {
+					return &mockRow{
+						scanFn: func(dest ...any) error {
+							count, ok := dest[0].(*int)
+							require.True(t, ok)
+							*count = 0
+							return nil
+						},
+					}, nil
+				},
+			},
+			lastActive: time.Time{},
+
+			wantLastActive: now,
+			wantActive:     true,
+			wantErr:        nil,
+		},
+		{
+			name:   "last active is zero, cluster is active",
+			client: &mockClusterClient{},
+			querier: &mockQuerier{
+				queryFunc: func(ctx context.Context, query string, args ...any) (postgres.Row, error) {
+					return &mockRow{
+						scanFn: func(dest ...any) error {
+							count, ok := dest[0].(*int)
+							require.True(t, ok)
+							*count = 2
+							return nil
+						},
+					}, nil
+				},
+			},
+			lastActive: time.Time{},
+
+			wantLastActive: now,
+			wantActive:     true,
+			wantErr:        nil,
+		},
+		{
 			name:   "openConnections returns error",
 			client: &mockClusterClient{},
 			querier: &mockQuerier{


### PR DESCRIPTION
Currently when a cluster has scale to zero disabled on startup, and it is enabled later on, the inactivity period starts counting from the time the cluster was started, instead of when the scale to zero setting was enabled. 

This PR updates the logic to reset the last active time whenever the scale to zero is disabled, so that when it's (re)enabled, it restarts the inactivity period timer.