### PR TITLE
Add evaluate capabilities

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,9 +36,9 @@ make deploy
 # Create a kind cluster
 kind create cluster --name cnpg-i-scale-to-zero
 
-# Install CloudNativePG
+# Install CloudNativePG (at least version 1.26.0)
 kubectl apply --server-side -f \
-  https://github.com/cloudnative-pg/cloudnative-pg/releases/download/v1.24.1/cnpg-1.24.1.yaml
+  https://github.com/cloudnative-pg/cloudnative-pg/releases/download/v1.26.0/cnpg-1.26.0.yaml
 
 # Install cert-manager
 kubectl apply -f \
@@ -142,13 +142,16 @@ make undeploy
 ### Hibernation not working
 
 1. **Check RBAC permissions**: Verify the cluster has the required RBAC configuration:
+
    ```bash
    kubectl get clusterrolebinding my-cluster-scale-to-zero-binding
    ```
+
    If missing, apply the [RBAC template](doc/examples/rbac-template.yaml) with your cluster name and namespace.
 
 2. Check sidecar logs for database connection issues
 3. Verify the cluster annotations are correctly set:
+
    ```bash
    kubectl get cluster my-cluster -o yaml | grep -A 5 annotations
    ```

--- a/internal/plugin/lifecycle/lifecycle.go
+++ b/internal/plugin/lifecycle/lifecycle.go
@@ -46,6 +46,9 @@ func (impl Implementation) GetCapabilities(
 					{
 						Type: lifecycle.OperatorOperationType_TYPE_CREATE,
 					},
+					{
+						Type: lifecycle.OperatorOperationType_TYPE_EVALUATE,
+					},
 				},
 			},
 		},
@@ -66,11 +69,14 @@ func (impl Implementation) LifecycleHook(
 		return nil, errors.New("no operation set")
 	}
 
+	log.FromContext(ctx).Info("reconciling object", "kind", kind, "operation", operation)
+
 	//nolint: gocritic
 	switch kind {
 	case "Pod":
 		switch *operation {
-		case lifecycle.OperatorOperationType_TYPE_CREATE:
+		case lifecycle.OperatorOperationType_TYPE_CREATE,
+			lifecycle.OperatorOperationType_TYPE_EVALUATE:
 			return impl.reconcileMetadata(ctx, request)
 		}
 	}


### PR DESCRIPTION
This PR adds evaluate capabilities to the lifecycle implementation. This will allow the scale to zero plugin to inject the sidecar not only for new clusters, but also for existing ones, by reacting to the rollout triggered by cluster patches (such as adding a plugin to the cluster spec).