### PR TITLE
Pause scheduled backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ This plugin monitors PostgreSQL database activity and automatically scales clust
 1. **Sidecar Injection**: Automatically adds a monitoring sidecar to the primary PostgreSQL pod
 2. **Activity Monitoring**: The sidecar periodically checks for active database connections and recent queries
 3. **Automatic Hibernation**: When the cluster is inactive for the configured duration, it sets the hibernation annotation
-4. **Resource Optimization**: Inactive clusters are scaled to zero, freeing up cluster resources
+4. **Scheduled Backup Management**: Automatically pauses scheduled backups when the cluster is hibernated to prevent backup failures
+5. **Resource Optimization**: Inactive clusters are scaled to zero, freeing up cluster resources
 
 ## Installation
 
@@ -78,13 +79,13 @@ The plugin behavior is configured through cluster annotations:
 - `xata.io/scale-to-zero-enabled`: Set to `"true"` to enable scale-to-zero functionality
 - `xata.io/scale-to-zero-inactivity-minutes`: Sets the inactivity threshold in minutes before hibernation (default: 30 minutes)
 
-The plugin automatically manages the `cnpg.io/hibernation` annotation to trigger cluster hibernation.
+The plugin automatically manages the `cnpg.io/hibernation` annotation to trigger cluster hibernation and pauses any associated scheduled backups to prevent backup failures on hibernated clusters.
 
 See the [cluster example](doc/examples/cluster-example.yaml) for a complete configuration.
 
 #### RBAC
 
-**Important**: Each cluster that uses scale-to-zero functionality requires specific RBAC permissions for the sidecar to update cluster resources.
+**Important**: Each cluster that uses scale-to-zero functionality requires specific RBAC permissions for the sidecar to update cluster resources and manage scheduled backups.
 
 Create the required RBAC using the template:
 
@@ -177,6 +178,7 @@ The plugin provides logging to help monitor its operation:
 - Sidecar injection events are logged during pod creation
 - Activity monitoring status is logged at each check interval
 - Hibernation events are logged when clusters are scaled down
+- Scheduled backup pause operations are logged
 
 You can view the plugin logs using:
 

--- a/doc/development.md
+++ b/doc/development.md
@@ -89,6 +89,7 @@ The scale-to-zero plugin specifically:
 - Monitors Pod creation events
 - Injects a sidecar container into the primary PostgreSQL pod only
 - The sidecar monitors database activity and hibernates inactive clusters
+- Manages scheduled backups by pausing them during hibernation
 
 ### Sidecar Implementation
 
@@ -115,6 +116,8 @@ inactive clusters:
 - **Configurable Inactivity Threshold**: Uses the `xata.io/scale-to-zero-inactivity-minutes`
   annotation to determine when a cluster should be hibernated (defaults to 30 minutes)
 - **Hibernation**: Sets the `cnpg.io/hibernation` annotation to scale the cluster to zero
+- **Scheduled Backup Management**: Automatically pauses scheduled backups when hibernating
+  clusters to prevent backup failures on inactive clusters
 - **Primary-Only Operation**: Only runs on the primary PostgreSQL instance
 
 Key features:
@@ -123,6 +126,7 @@ Key features:
 - PostgreSQL connection pooling for activity monitoring
 - Graceful shutdown on context cancellation
 - Error handling for replica instances (stops monitoring if not primary)
+- Automatic scheduled backup pause operations
 
 #### Environment Variables
 
@@ -171,6 +175,10 @@ are inactive for a specified period. Here's how it operates:
    the sidecar sets the `cnpg.io/hibernation` annotation on the cluster, causing
    CloudNativePG to scale it down to zero replicas.
 
+5. **Scheduled Backup Management**: After hibernating a cluster, the sidecar automatically
+   pauses any associated scheduled backups to prevent backup operations from failing
+   on hibernated clusters.
+
 ### Configuration
 
 The plugin behavior can be configured through cluster annotations:
@@ -188,7 +196,7 @@ The injected sidecar container is configurable and uses environment-based config
 - **Configurable via**: `SIDECAR_IMAGE` environment variable or `--sidecar-image` flag
 - Environment variables for cluster identification
 - Direct access to the PostgreSQL database
-- Kubernetes API access for cluster management
+- Kubernetes API access for cluster and scheduled backup management
 - Configurable check intervals and inactivity thresholds
 
 ## Build and deploy the plugin

--- a/doc/examples/cluster-example.yaml
+++ b/doc/examples/cluster-example.yaml
@@ -30,3 +30,14 @@ spec:
 
   storage:
     size: 1Gi
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: cluster-example
+  namespace: default
+spec:
+  schedule: "0 0 2 * * *"  # Daily at 2 AM (seconds, minutes, hours, day of month, month, day of week)
+  cluster:
+    name: cluster-example
+  backupOwnerReference: self

--- a/internal/sidecar/cluster_client.go
+++ b/internal/sidecar/cluster_client.go
@@ -126,6 +126,18 @@ func (r *cnpgClusterClient) getClusterCredentials(ctx context.Context) (*postgre
 	return creds, nil
 }
 
+func (r *cnpgClusterClient) getClusterScheduledBackup(ctx context.Context) (*cnpgv1.ScheduledBackup, error) {
+	scheduledBackup := &cnpgv1.ScheduledBackup{}
+	if err := r.client.Get(ctx, r.clusterKey, scheduledBackup); err != nil {
+		return nil, err
+	}
+	return scheduledBackup, nil
+}
+
+func (r *cnpgClusterClient) updateClusterScheduledBackup(ctx context.Context, scheduledBackup *cnpgv1.ScheduledBackup) error {
+	return r.client.Update(ctx, scheduledBackup)
+}
+
 func (p *postgreSQLCredentials) connString() string {
 	return fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=require",
 		p.host, p.port, p.username, p.password, p.database)

--- a/internal/sidecar/helper_test.go
+++ b/internal/sidecar/helper_test.go
@@ -8,9 +8,11 @@ import (
 )
 
 type mockClusterClient struct {
-	getClusterFunc            func(ctx context.Context, forceUpdate bool) (*cnpgv1.Cluster, error)
-	updateClusterFunc         func(ctx context.Context, cluster *cnpgv1.Cluster) error
-	getClusterCredentialsFunc func(ctx context.Context) (*postgreSQLCredentials, error)
+	getClusterFunc                   func(ctx context.Context, forceUpdate bool) (*cnpgv1.Cluster, error)
+	updateClusterFunc                func(ctx context.Context, cluster *cnpgv1.Cluster) error
+	getClusterCredentialsFunc        func(ctx context.Context) (*postgreSQLCredentials, error)
+	getClusterScheduledBackupFunc    func(ctx context.Context) (*cnpgv1.ScheduledBackup, error)
+	updateClusterScheduledBackupFunc func(ctx context.Context, scheduledBackup *cnpgv1.ScheduledBackup) error
 }
 
 func (m *mockClusterClient) getCluster(ctx context.Context, forceUpdate bool) (*cnpgv1.Cluster, error) {
@@ -32,6 +34,20 @@ func (m *mockClusterClient) getClusterCredentials(ctx context.Context) (*postgre
 		return m.getClusterCredentialsFunc(ctx)
 	}
 	return nil, nil
+}
+
+func (m *mockClusterClient) getClusterScheduledBackup(ctx context.Context) (*cnpgv1.ScheduledBackup, error) {
+	if m.getClusterScheduledBackupFunc != nil {
+		return m.getClusterScheduledBackupFunc(ctx)
+	}
+	return nil, nil
+}
+
+func (m *mockClusterClient) updateClusterScheduledBackup(ctx context.Context, scheduledBackup *cnpgv1.ScheduledBackup) error {
+	if m.updateClusterScheduledBackupFunc != nil {
+		return m.updateClusterScheduledBackupFunc(ctx, scheduledBackup)
+	}
+	return nil
 }
 
 type mockQuerier struct {

--- a/internal/sidecar/sidecar.go
+++ b/internal/sidecar/sidecar.go
@@ -82,7 +82,9 @@ func generateScheme(ctx context.Context) *runtime.Scheme {
 	// Proceed with custom registration of the CNPG scheme
 	schemeGroupVersion := schema.GroupVersion{Group: cnpgGroup, Version: cnpgVersion}
 	schemeBuilder := &scheme.Builder{GroupVersion: schemeGroupVersion}
-	schemeBuilder.Register(&cnpgv1.Cluster{}, &cnpgv1.ClusterList{})
+	schemeBuilder.Register(
+		&cnpgv1.Cluster{}, &cnpgv1.ClusterList{},
+		&cnpgv1.ScheduledBackup{}, &cnpgv1.ScheduledBackupList{})
 	utilruntime.Must(schemeBuilder.AddToScheme(result))
 
 	schemeLog := log.FromContext(ctx)

--- a/kubernetes/rbac.yaml
+++ b/kubernetes/rbac.yaml
@@ -9,7 +9,7 @@ metadata:
   name: cnpg-scale-to-zero-sidecar-role
 rules:
 - apiGroups: ["postgresql.cnpg.io"]
-  resources: ["clusters"]
+  resources: ["clusters", "scheduledbackups"]
   verbs: ["get", "list", "watch", "update", "patch"]
 - apiGroups: [""]
   resources: ["secrets"]

--- a/manifest-dev.yaml
+++ b/manifest-dev.yaml
@@ -13,6 +13,7 @@ rules:
   - postgresql.cnpg.io
   resources:
   - clusters
+  - scheduledbackups
   verbs:
   - get
   - list

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -13,6 +13,7 @@ rules:
   - postgresql.cnpg.io
   resources:
   - clusters
+  - scheduledbackups
   verbs:
   - get
   - list


### PR DESCRIPTION
This PR updates the scale to zero sidecar behaviour to suspend the cluster scheduled backups if any after the cluster is successfully hibernated to prevent errors.

https://cloudnative-pg.io/documentation/1.26/backup/#pause-scheduled-backups