### PR TITLE
Do not hibernate if backup is in progress

### DIFF
--- a/doc/examples/cluster-example.yaml
+++ b/doc/examples/cluster-example.yaml
@@ -38,6 +38,7 @@ metadata:
   namespace: default
 spec:
   schedule: "0 0 2 * * *"  # Daily at 2 AM (seconds, minutes, hours, day of month, month, day of week)
+  immediate: true
   cluster:
     name: cluster-example
   backupOwnerReference: self

--- a/internal/sidecar/cluster_client.go
+++ b/internal/sidecar/cluster_client.go
@@ -138,6 +138,19 @@ func (r *cnpgClusterClient) updateClusterScheduledBackup(ctx context.Context, sc
 	return r.client.Update(ctx, scheduledBackup)
 }
 
+func (r *cnpgClusterClient) getClusterBackups(ctx context.Context) ([]cnpgv1.Backup, error) {
+	// Use label selector to filter backups for this cluster
+	listOptions := []client.ListOption{
+		client.InNamespace(r.clusterKey.Namespace),
+		client.MatchingLabels{"cnpg.io/cluster": r.clusterKey.Name},
+	}
+	var backupList cnpgv1.BackupList
+	if err := r.client.List(ctx, &backupList, listOptions...); err != nil {
+		return nil, err
+	}
+	return backupList.Items, nil
+}
+
 func (p *postgreSQLCredentials) connString() string {
 	return fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=require",
 		p.host, p.port, p.username, p.password, p.database)

--- a/internal/sidecar/helper_test.go
+++ b/internal/sidecar/helper_test.go
@@ -13,6 +13,8 @@ type mockClusterClient struct {
 	getClusterCredentialsFunc        func(ctx context.Context) (*postgreSQLCredentials, error)
 	getClusterScheduledBackupFunc    func(ctx context.Context) (*cnpgv1.ScheduledBackup, error)
 	updateClusterScheduledBackupFunc func(ctx context.Context, scheduledBackup *cnpgv1.ScheduledBackup) error
+	getClusterBackupsFunc            func(ctx context.Context, i uint) ([]cnpgv1.Backup, error)
+	getClusterBackupsCalls           uint
 }
 
 func (m *mockClusterClient) getCluster(ctx context.Context, forceUpdate bool) (*cnpgv1.Cluster, error) {
@@ -48,6 +50,14 @@ func (m *mockClusterClient) updateClusterScheduledBackup(ctx context.Context, sc
 		return m.updateClusterScheduledBackupFunc(ctx, scheduledBackup)
 	}
 	return nil
+}
+
+func (m *mockClusterClient) getClusterBackups(ctx context.Context) ([]cnpgv1.Backup, error) {
+	m.getClusterBackupsCalls++
+	if m.getClusterBackupsFunc != nil {
+		return m.getClusterBackupsFunc(ctx, m.getClusterBackupsCalls)
+	}
+	return []cnpgv1.Backup{}, nil
 }
 
 type mockQuerier struct {

--- a/internal/sidecar/sidecar.go
+++ b/internal/sidecar/sidecar.go
@@ -35,6 +35,8 @@ func Start(ctx context.Context) error {
 			DisableFor: []client.Object{
 				&corev1.Secret{},
 				&cnpgv1.Cluster{},
+				&cnpgv1.ScheduledBackup{},
+				&cnpgv1.Backup{},
 			},
 		},
 	}
@@ -84,7 +86,8 @@ func generateScheme(ctx context.Context) *runtime.Scheme {
 	schemeBuilder := &scheme.Builder{GroupVersion: schemeGroupVersion}
 	schemeBuilder.Register(
 		&cnpgv1.Cluster{}, &cnpgv1.ClusterList{},
-		&cnpgv1.ScheduledBackup{}, &cnpgv1.ScheduledBackupList{})
+		&cnpgv1.ScheduledBackup{}, &cnpgv1.ScheduledBackupList{},
+		&cnpgv1.Backup{}, &cnpgv1.BackupList{})
 	utilruntime.Must(schemeBuilder.AddToScheme(result))
 
 	schemeLog := log.FromContext(ctx)


### PR DESCRIPTION
This PR updates the scale to zero sidecar logic to only hibernate a cluster if there are no backups ongoing. 