### PR TITLE
Bump `cnpg-i-machinery` to `v0.4.0`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.4
 require (
 	github.com/cloudnative-pg/cloudnative-pg v1.26.1
 	github.com/cloudnative-pg/cnpg-i v0.2.1
-	github.com/cloudnative-pg/cnpg-i-machinery v0.3.0
+	github.com/cloudnative-pg/cnpg-i-machinery v0.4.0
 	github.com/cloudnative-pg/machinery v0.3.0
 	github.com/jackc/pgx/v5 v5.7.5
 	github.com/lib/pq v1.10.9

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/cloudnative-pg/cnpg-i v0.2.1 h1:g96BE1ojdiFtDwtb7tg5wUF9a2kAh0eVg4Skj
 github.com/cloudnative-pg/cnpg-i v0.2.1/go.mod h1:kPfJpPGAKN1/2xvwBcC3WzMP46pj3sKLHLNB8NHr77U=
 github.com/cloudnative-pg/cnpg-i-machinery v0.3.0 h1:k/HBe7FGE/WDrYCMpRm9t5r/PG8FfJKLS3ZFhaM39Ik=
 github.com/cloudnative-pg/cnpg-i-machinery v0.3.0/go.mod h1:/+n6X/IT/Q7+N/oI/Ddh5Ot938BZ2F/vU5p53G1TZHo=
+github.com/cloudnative-pg/cnpg-i-machinery v0.4.0 h1:16wQt9qFFqvyxeg+9dPt8ic8dh3PRPq0jCGXVuZyjO4=
+github.com/cloudnative-pg/cnpg-i-machinery v0.4.0/go.mod h1:4MCJzbCOsB7ianxlm8rqD+gDpkgVTHoTuglle/i72WA=
 github.com/cloudnative-pg/machinery v0.3.0 h1:t1DzXGeK3RUYXS5KWIdIk30oh4EmwxZ+6sWM4wJDBac=
 github.com/cloudnative-pg/machinery v0.3.0/go.mod h1:6NhajP3JlioeecYceVuOBLD2lfsJty8qSZsFpSb/vmA=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/internal/plugin/lifecycle/lifecycle.go
+++ b/internal/plugin/lifecycle/lifecycle.go
@@ -134,6 +134,8 @@ func (impl Implementation) reconcileMetadata(
 		"primary", cluster.Status.CurrentPrimary,
 		"resources", sidecarContainer.Resources)
 
+	// migrate to InjectPluginInitContainerSidecarSpec (means dropping support for k8s < 1.29)
+	//nolint:staticcheck
 	err = object.InjectPluginSidecar(mutatedPod, sidecarContainer, false)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Update the [cnpg-i-machinery](https://github.com/cloudnative-pg/cnpg-i-machinery)  dependency to `v0.4.0`.

This is to take advantage of the client cert reload behaviour added in https://github.com/cloudnative-pg/cnpg-i-machinery/pull/197.