### PR TITLE
Remove `errReplicaInstance` and handling

### DIFF
--- a/internal/sidecar/scale_to_zero.go
+++ b/internal/sidecar/scale_to_zero.go
@@ -56,8 +56,6 @@ const (
 	defaultCheckInterval     = 1 * time.Minute // default check interval for cluster activity
 )
 
-var errReplicaInstance = errors.New("current pod is not the primary instance")
-
 // newScaleToZero creates a new scaleToZero instance with the provided configuration and client.
 func newScaleToZero(ctx context.Context, cfg config, client client.Client) (*scaleToZero, error) {
 	s := &scaleToZero{
@@ -125,10 +123,6 @@ func (s *scaleToZero) Start(ctx context.Context) error {
 			if !isActive {
 				if err := s.hibernate(ctx); err != nil {
 					contextLogger.Error(err, "hibernation failed")
-					// we stop the scale to zero sidecar if this is not the primary instance
-					if errors.Is(err, errReplicaInstance) {
-						return nil
-					}
 					// if hibernation fails, do not try pausing the scheduled backup
 					continue
 				}

--- a/internal/sidecar/scale_to_zero_test.go
+++ b/internal/sidecar/scale_to_zero_test.go
@@ -441,54 +441,6 @@ func TestScaleToZero_Start(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name: "cluster with scale to zero enabled and inactive cluster, hibernation error replica instance stops the process",
-			client: func(done chan struct{}) *mockClusterClient {
-				return &mockClusterClient{
-					getClusterFunc: func(ctx context.Context, forceUpdate bool) (*cnpgv1.Cluster, error) {
-						return &cnpgv1.Cluster{
-							Status: cnpgv1.ClusterStatus{
-								Phase:          healthyClusterStatus,
-								CurrentPrimary: "test-pod-1",
-							},
-							ObjectMeta: metav1.ObjectMeta{
-								Annotations: map[string]string{
-									scaleToZeroEnabledAnnotation: "true",
-									inactivityMinutesAnnotation:  "5",
-								},
-							},
-						}, nil
-					},
-					updateClusterFunc: func(ctx context.Context, cluster *cnpgv1.Cluster) error {
-						defer func() { done <- struct{}{} }()
-						require.NotNil(t, cluster)
-						require.Equal(t, "on", cluster.Annotations[hibernationAnnotation])
-						return errReplicaInstance
-					},
-					getClusterScheduledBackupFunc: func(ctx context.Context) (*cnpgv1.ScheduledBackup, error) {
-						return nil, fmt.Errorf("scheduledbackups.postgresql.cnpg.io \"test-cluster\" not found")
-					},
-				}
-			},
-			querier: func(_ chan struct{}) *mockQuerier {
-				return &mockQuerier{
-					queryFunc: func(ctx context.Context, query string, args ...any) (postgres.Row, error) {
-						return &mockRow{
-							scanFn: func(dest ...any) error {
-								require.Len(t, dest, 1)
-								count, ok := dest[0].(*int)
-								require.True(t, ok)
-								*count = 0 // Simulate an inactive cluster
-								return nil
-							},
-						}, nil
-					},
-				}
-			},
-			lastActive: time.Now().Add(-time.Minute * 10), // Simulate inactivity
-
-			wantErr: nil,
-		},
-		{
 			name: "cluster with scale to zero enabled, unable to check activity, error ignored",
 			client: func(done chan struct{}) *mockClusterClient {
 				return &mockClusterClient{
@@ -940,25 +892,6 @@ func Test_hibernate(t *testing.T) {
 				},
 			},
 			wantErr: errTest,
-		},
-		{
-			name: "updateCluster returns errReplicaInstance",
-			client: &mockClusterClient{
-				getClusterFunc: func(ctx context.Context, forceUpdate bool) (*cnpgv1.Cluster, error) {
-					return &cnpgv1.Cluster{
-						Status: cnpgv1.ClusterStatus{
-							Phase: healthyClusterStatus,
-						},
-						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{},
-						},
-					}, nil
-				},
-				updateClusterFunc: func(ctx context.Context, cluster *cnpgv1.Cluster) error {
-					return errReplicaInstance
-				},
-			},
-			wantErr: errReplicaInstance,
 		},
 	}
 


### PR DESCRIPTION
`errReplicaInstance` is never returned anywhere in the code outside of tests.

It looks as though the intention may once have been to have the sidecar stop if not running on the primary.

However the check here suggests it should keep running but not poll for activity:

https://github.com/xataio/cnpg-i-scale-to-zero/blob/37b3d00f1ea7df577eef894a19fb2964407b0f31/internal/sidecar/scale_to_zero.go?plain=1#L97-L105