### PR TITLE
fix: remove secret need

### DIFF
--- a/internal/plugin/lifecycle/lifecycle.go
+++ b/internal/plugin/lifecycle/lifecycle.go
@@ -103,8 +103,6 @@ func (impl Implementation) reconcileMetadata(
 
 	mutatedPod := pod.DeepCopy()
 
-	superuserSecret := cluster.Name + "-superuser"
-	superuserVolume := "superuser-credentials"
 	sidecarContainer := &corev1.Container{
 		Name:  "scale-to-zero",
 		Image: impl.sidecarImage,
@@ -126,11 +124,14 @@ func (impl Implementation) reconcileMetadata(
 				Value: impl.logLevel,
 			},
 		},
+		// Mount the scratch-data volume (created by CNPG) so the sidecar can
+		// reach postgres over its Unix socket at /controller/run/.s.PGSQL.5432.
+		// Auth is peer + ident map; both containers run as the pod-level UID 26.
 		VolumeMounts: []corev1.VolumeMount{
 			{
-				Name:      superuserVolume,
-				MountPath: "/etc/superuser",
-				ReadOnly:  true,
+				Name:      "scratch-data",
+				MountPath: "/controller/run",
+				SubPath:   "run",
 			},
 		},
 		Resources: impl.sidecarResources,
@@ -149,15 +150,6 @@ func (impl Implementation) reconcileMetadata(
 	if err != nil {
 		return nil, err
 	}
-
-	mutatedPod.Spec.Volumes = append(mutatedPod.Spec.Volumes, corev1.Volume{
-		Name: superuserVolume,
-		VolumeSource: corev1.VolumeSource{
-			Secret: &corev1.SecretVolumeSource{
-				SecretName: superuserSecret,
-			},
-		},
-	})
 
 	patch, err := object.CreatePatch(mutatedPod, pod)
 	if err != nil {

--- a/internal/sidecar/cluster_client.go
+++ b/internal/sidecar/cluster_client.go
@@ -3,8 +3,6 @@ package sidecar
 import (
 	"context"
 	"fmt"
-	"os"
-	"strings"
 	"time"
 
 	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -27,7 +25,6 @@ type cnpgClusterClient struct {
 // postgreSQLCredentials holds the connection information for PostgreSQL
 type postgreSQLCredentials struct {
 	username string
-	password string
 	database string
 	host     string
 	port     string
@@ -80,40 +77,19 @@ func (r *cnpgClusterClient) getCluster(ctx context.Context, forceUpdate bool) (*
 	return r.cluster, nil
 }
 
-const credentialsPath = "/etc/superuser" //nolint:gosec // filesystem path, not a credential
+// socketDir is the Unix socket directory used by CNPG for the PostgreSQL
+// server. The sidecar container, running with the same UID as the postgres
+// container, authenticates as the "postgres" role via peer auth over this
+// socket — no password required.
+const socketDir = "/controller/run"
 
 func (r *cnpgClusterClient) getClusterCredentials(_ context.Context) (*postgreSQLCredentials, error) {
-	username, err := readCredentialFile(credentialsPath + "/username")
-	if err != nil {
-		return nil, fmt.Errorf("read superuser username: %w", err)
-	}
-	password, err := readCredentialFile(credentialsPath + "/password")
-	if err != nil {
-		return nil, fmt.Errorf("read superuser password: %w", err)
-	}
-	database, err := readCredentialFile(credentialsPath + "/dbname")
-	if err != nil {
-		return nil, fmt.Errorf("read superuser dbname: %w", err)
-	}
-	if database == "*" || database == "" {
-		database = "postgres"
-	}
-
 	return &postgreSQLCredentials{
-		username: username,
-		password: password,
-		database: database,
-		host:     "localhost",
+		username: "postgres",
+		database: "postgres",
+		host:     socketDir,
 		port:     "5432",
 	}, nil
-}
-
-func readCredentialFile(path string) (string, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(data)), nil
 }
 
 func (r *cnpgClusterClient) getClusterScheduledBackup(ctx context.Context) (*cnpgv1.ScheduledBackup, error) {
@@ -129,6 +105,6 @@ func (r *cnpgClusterClient) updateClusterScheduledBackup(ctx context.Context, sc
 }
 
 func (p *postgreSQLCredentials) connString() string {
-	return fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=require",
-		p.host, p.port, p.username, p.password, p.database)
+	return fmt.Sprintf("host=%s port=%s user=%s dbname=%s sslmode=disable application_name=scale-to-zero",
+		p.host, p.port, p.username, p.database)
 }


### PR DESCRIPTION
Remove the need for any secret by mounting the Unix socket on thesidecar
and connecting directly. This works since the pod sets the user and
group ID, and the containers inherit it. Making the sidecar connect to
postgres like the instance manager does it.