### PR TITLE
Remove unneeded permissions

### DIFF
--- a/kubernetes/rbac.yaml
+++ b/kubernetes/rbac.yaml
@@ -10,7 +10,7 @@ metadata:
 rules:
 - apiGroups: ["postgresql.cnpg.io"]
   resources: ["clusters", "scheduledbackups"]
-  verbs: ["get", "list", "watch", "update", "patch"]
+  verbs: ["get", "update", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/manifest-dev.yaml
+++ b/manifest-dev.yaml
@@ -16,8 +16,6 @@ rules:
   - scheduledbackups
   verbs:
   - get
-  - list
-  - watch
   - update
   - patch
 ---

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -16,8 +16,6 @@ rules:
   - scheduledbackups
   verbs:
   - get
-  - list
-  - watch
   - update
   - patch
 ---


### PR DESCRIPTION
Sidecar still has to update the cluster and backup but we do not need to
list or watch. Remove those to give it as little as possible.