### PR TITLE
chore: bump Go to 1.26.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.26.3"
           cache: true
 
       - name: Download dependencies
@@ -44,13 +44,13 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.26.3"
           cache: true
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.1.0
+          version: v2.12.2
 
   docker-build:
     needs: [test, lint]

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  go: "1.24"
+  go: "1.26"
 linters:
   default: none
   enable:

--- a/Dockerfile.plugin
+++ b/Dockerfile.plugin
@@ -1,5 +1,5 @@
 # Step 1: build image
-FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.3 AS builder
 
 # Set up cross-compilation
 ARG TARGETPLATFORM

--- a/Dockerfile.sidecar
+++ b/Dockerfile.sidecar
@@ -1,5 +1,5 @@
 # Step 1: build image
-FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.3 AS builder
 
 # Set up cross-compilation
 ARG TARGETPLATFORM

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ help: ## Show this help message
 .PHONY: lint
 lint: ## Lint source code
 	@echo "Linting source code..."
-	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.0
+	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 	@golangci-lint run
 
 .PHONY: test

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/xataio/cnpg-i-scale-to-zero
 
-go 1.24.1
-
-toolchain go1.24.4
+go 1.26.3
 
 require (
 	github.com/cloudnative-pg/cloudnative-pg v1.26.1
@@ -18,6 +16,7 @@ require (
 	k8s.io/api v0.33.3
 	k8s.io/apimachinery v0.33.3
 	k8s.io/client-go v0.33.3
+	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 	sigs.k8s.io/controller-runtime v0.21.0
 )
 
@@ -93,7 +92,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.33.3 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
-	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,6 @@ github.com/cloudnative-pg/cloudnative-pg v1.26.1 h1:QKQHBVWQqAQNeLVX+YiXRS59kUga
 github.com/cloudnative-pg/cloudnative-pg v1.26.1/go.mod h1:YkYwK6vtBwH2NxCYXcvHeHjPCiuJwl4umlcAWlcMYXQ=
 github.com/cloudnative-pg/cnpg-i v0.2.1 h1:g96BE1ojdiFtDwtb7tg5wUF9a2kAh0eVg4SkjsO8jnk=
 github.com/cloudnative-pg/cnpg-i v0.2.1/go.mod h1:kPfJpPGAKN1/2xvwBcC3WzMP46pj3sKLHLNB8NHr77U=
-github.com/cloudnative-pg/cnpg-i-machinery v0.3.0 h1:k/HBe7FGE/WDrYCMpRm9t5r/PG8FfJKLS3ZFhaM39Ik=
-github.com/cloudnative-pg/cnpg-i-machinery v0.3.0/go.mod h1:/+n6X/IT/Q7+N/oI/Ddh5Ot938BZ2F/vU5p53G1TZHo=
 github.com/cloudnative-pg/cnpg-i-machinery v0.4.0 h1:16wQt9qFFqvyxeg+9dPt8ic8dh3PRPq0jCGXVuZyjO4=
 github.com/cloudnative-pg/cnpg-i-machinery v0.4.0/go.mod h1:4MCJzbCOsB7ianxlm8rqD+gDpkgVTHoTuglle/i72WA=
 github.com/cloudnative-pg/machinery v0.3.0 h1:t1DzXGeK3RUYXS5KWIdIk30oh4EmwxZ+6sWM4wJDBac=

--- a/internal/sidecar/scale_to_zero.go
+++ b/internal/sidecar/scale_to_zero.go
@@ -49,8 +49,9 @@ const (
 	healthyClusterStatus  = "Cluster in healthy state"
 	hibernationAnnotation = "cnpg.io/hibernation"
 
-	scaleToZeroEnabledAnnotation = "xata.io/scale-to-zero-enabled"
-	inactivityMinutesAnnotation  = "xata.io/scale-to-zero-inactivity-minutes"
+	scaleToZeroEnabledAnnotation     = "xata.io/scale-to-zero-enabled"
+	scaleToZeroEnabledAnnotationTrue = "true"
+	inactivityMinutesAnnotation      = "xata.io/scale-to-zero-inactivity-minutes"
 
 	defaultInactivityMinutes = 30              // default inactivity minutes if not set in the annotation
 	defaultCheckInterval     = 1 * time.Minute // default check interval for cluster activity
@@ -258,7 +259,7 @@ func (s *scaleToZero) getClusterScaleToZeroConfig(ctx context.Context, cluster *
 	enabled := false
 	inactivityMinutes := defaultInactivityMinutes
 
-	if value, exists := cluster.Annotations[scaleToZeroEnabledAnnotation]; exists && value == "true" {
+	if value, exists := cluster.Annotations[scaleToZeroEnabledAnnotation]; exists && value == scaleToZeroEnabledAnnotationTrue {
 		enabled = true
 	}
 


### PR DESCRIPTION
## Summary
- Bump `go` directive, toolchain, CI workflows, Dockerfiles, and `.golangci.yml` to Go 1.26.3
- Bump `golangci-lint` to v2.12.2 (the older v2.1.0 is built with Go ≤1.25 and refuses to analyse code targeting Go 1.26)
- Extract the scale-to-zero `"true"` annotation value into a named constant to satisfy `goconst` under the newer linter

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -cover ./...`
- [x] `golangci-lint run` (v2.12.2)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)